### PR TITLE
write default environment to u-boot-env flash partition if no environment vars set

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -58,7 +58,7 @@ build_uboot() {
 
     echo "Building U-Boot for $TARGET_DEVICE"
     make ${TARGET_DEVICE}_defconfig
-    make ARCH=${TARGET_ARCH} CROSS_COMPILE=${TARGET_CROSS_COMPILE}
+    eval "make ARCH=${TARGET_ARCH} CROSS_COMPILE=${TARGET_CROSS_COMPILE} ${COMPILE_FLAGS}"
     if [ $? -ne 0 ]; then
         echo "Build failed"
         exit 1

--- a/profile
+++ b/profile
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 REPO="https://github.com/OnionIoT/u-boot"
-COMMIT="5f87035d7d82fdc72ba872308bf9f4998f2e57f5"
+COMMIT="317613c4c42e882f310265d8a9e9e0c1dcb80085"
 UBOOT_RELEASE="v2025.04"
 
 TARGET_DEVICE="onion-omega2p"

--- a/profile
+++ b/profile
@@ -7,5 +7,4 @@ UBOOT_RELEASE="v2025.04"
 TARGET_DEVICE="onion-omega2p"
 TARGET_ARCH="mips"
 TARGET_CROSS_COMPILE="mipsel-linux-gnu-"
-
-
+COMPILE_FLAGS='KCFLAGS="-Os -pipe -fno-caller-saves"'


### PR DESCRIPTION
Changes: 
- If the u-boot-env partition is empty, u-boot will now write the default environment to the u-boot-env partition - see https://github.com/OnionIoT/u-boot/commit/317613c4c42e882f310265d8a9e9e0c1dcb80085
- Updated u-boot-wrapper to set compiler flags - need size optimization `-Os` flag with generic mipsel compiler to keep u-boot-with-spl image < 192kb